### PR TITLE
Feature: Language parsing

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -28,6 +28,11 @@ pub enum DictError {
         backtrace: Backtrace,
     },
 
+    #[fail(display = "Language code not found")]
+    LanguageCodeNotFound {
+        backtrace: Backtrace,
+    },
+
     #[fail(display = "{}", _0)]
     Io(#[cause] io::Error),
 

--- a/src/parse/debug.rs
+++ b/src/parse/debug.rs
@@ -4,26 +4,13 @@ extern crate regex;
 
 use error::DictResult;
 use dict::{Dict, QueryDirection};
-use regex::Regex;
 
 pub fn parse_test(path: &str) -> DictResult<()> {
-
-    // Header
-    {
-        let mut with_header = csv::ReaderBuilder::new().from_path(path)?;
-        let header = with_header.headers().unwrap();
-        let re = Regex::new("[A-Z]{2}-[A-Z]{2}").unwrap();
-        let mat = re.find(header.get(0).unwrap()).unwrap();
-        println!("HEADER: {:?}", header);
-        println!("matches: {:?}", mat.as_str());
-
-    }
-    // --- Header
-
-
     let dict = Dict::create(path)?;
     let mut dq = dict.query();
 
+    println!("Left Language: {}\tRight Language: {}",
+             dict.get_left_language(), dict.get_right_language());
     loop {
         println!("Direction (left, right or both):");
         let mut direction = String::new();


### PR DESCRIPTION
+ Added functions to return left and right language
+ Listed all available languages
+ Removed header parsing from debug, instead added display of left and right lang.

- [x] Maybe you've got a better idea than return an `InvalidLanguageCode` with `<NONE>` in [line 111](https://github.com/kedeggel/dictcc-rust/compare/feature-language-parsing?expand=1#diff-702b5242a80e4ccdbdc2ca9eea2d4cffR111)